### PR TITLE
Add shasums + minor edits

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,25 +1,22 @@
 # Author: Matt McDonald <gardotd426@gmail.com>
 # Contributor: Kevin Gilmer
+# Contributor: Avinash Duduskar <strykar@hotmail.com>
 # Maintainer: Matt McDonald <gardotd426@gmail.com>
 
 
 pkgbase=regolith-de
 pkgname=(regolith-i3 # (regolith-i3-gaps regolith-i3-gaps-session i3-gaps-wm i3-gaps-wm-dbg i3-snapshot i3xrocks gnome-flashback ubiquity-slideshow-regolith)
-         regolith-i3xrocks # allll the i3xrocks shit
-	 regolith-styles # alll the styles shit
-	 regolith-st 
-	 regolith-desktop-config
-
-)
+        regolith-i3xrocks # allll the i3xrocks shit
+        regolith-styles # alll the styles shit
+        regolith-st 
+        regolith-desktop-config)
 pkgver=1.4.1
 pkgrel=1
 arch=('x86_64')
-url=https://www.amd.com/en/support/kb/release-notes/rn-rad-lin-20-10-unified
+url=https://github.com/regolith-linux/regolith-desktop
 license=('custom: multiple')
 groups=('regolith-de')
 makedepends=('wget')
-
-#DLAGENTS='https::/usr/bin/wget --referer https://www.amd.com/en/support/kb/release-notes/rn-rad-lin-20-10-early-preview -N %u'
 
 source=(https://launchpad.net/~regolith-linux/+archive/ubuntu/release/+files/ayu-theme_0.2.0-1ubuntu1~ppa1_amd64.deb
 	https://launchpad.net/~regolith-linux/+archive/ubuntu/release/+files/cahuella_1.0.2-1_amd64.deb
@@ -69,60 +66,57 @@ source=(https://launchpad.net/~regolith-linux/+archive/ubuntu/release/+files/ayu
 	https://launchpad.net/~regolith-linux/+archive/ubuntu/release/+files/regolith-i3xrocks-config_3.0.21-1_amd64.deb
 	http://archive.ubuntu.com/ubuntu/pool/main/g/gnome-session/gnome-session-bin_3.36.0-2ubuntu1_amd64.deb
 	http://archive.ubuntu.com/ubuntu/pool/main/g/gnome-session/gnome-session-common_3.36.0-2ubuntu1_all.deb
-        flashback.patch
+    flashback.patch)
+sha256sums=('cf0d111e9bc12e163b930849105626e535550d066bac280052d83a0e4d458818'
+            '22bbf4aaf1870963befffae41bfe7c2a0c8b674b4b0d15554a68b80a5f2429e3'
+            '2c4060dda3ee2d3b4fc587d35a8e9c9e6e8e7cc63edf72cf1e17322b1700d902'
+            'c24204be51fcaa06ee5f621c8564d08b944ea9e13eb0dbe6a530f8cfb01baea7'
+            '05c66c372d378d2992ec59be553bd7de1cf0574d61313d84274f1e64bfe23d3b'
+            '70124968b0ee701bd6c6c71d5c6f4c4e417a984924c47e3007a58db59478a612'
+            '95b9821f515005ffa7361c96b98a1e87fd2f5057b32acc8d70647f78ca00e010'
+            '2722c4fdac1e120d2dda9e309ac85fed583e6eb738efe3cf3cbf389288aa5138'
+            '09201968ab0bcc63a46110e006680f1cbd807fdd4fce16d4b4eba34115bac941'
+            '8f2c3d7168440644b1e426e61948dda758a9a7f7040c1dd3ee7d41b306f624dd'
+            '82050c4f1a95faeb4fd34eada50028f855527ffeda4277a7563a050e81f5cd02'
+            'a5dfec5bf96a24778364c03b1143fe20f835bafb269ec0efe59841bc461f0f7c'
+            'b31a1d5d534d00b484cb4523a2c66ca5b6a95e2cbae54a6b896e8f1d39e15edc'
+            'e6808d545b806da2e97a848c7d169a7062879482f8e165776156094e0823e552'
+            '34323f51e63cac850262dc2d1ae44583c6678c1303e0faf4b5eb341cb953c1f2'
+            'f10f62cb431b1b8f70c706052a556dc2ff9801ecc0df0fadac292229ef87378e'
+            '5f1ad1df62a1a15f95e744d7a8eb2d0852ad00500050a7185dc98792ecd0b90f'
+            '78866fb8c7ad2d3079ed350eaa679b92bc96c6d8a5707bdc9c80f3ca91e4d6f2'
+            '7fa0bec204ebafae295ac873458a8bd0dabc273c9d99036a89f937a614a671ca'
+            '9e9825270ed40386e8b170834b9d331a6dab55624a7996cb56f3e9b664f32538'
+            '2d3707829ba24f60af0d7310b0f95a79ec6eb28f7eb3224b3a7419b35dc70858'
+            'ab7f7e25566327afc15baa23990ae0d5522132645a9f6331504f1d01eeff174e'
+            '636366aad3a4635e3df5ecc69bafa2f176d7f2c09fa9a472825dbb508119bf96'
+            'b2a5d6c1ad5543a710b5dd4f2e468b773f81d6083407ad999890a91e322aecc6'
+            '900c285972a9969b4d2d8bcd67dabccb817a2a77a102251d5dc1b2e254f095c8'
+            '9895a1388d8bb4bc6cd6cac47d198a18f46e54b3aa0ef330d5b622272e3a1fef'
+            'be2d3143a741b183f69f97fc719034e24e5f77d7e210b890db1ddf416335c267'
+            'e37fd4c1397178271479b6fb59bcb30b623c89ce13ae0d0f8ad158118ed5b763'
+            'b84219798b644e97a473f99f9deef9e1985be1608fdbed794755dde80b694795'
+            '9c641ad29504864ed08cd67f34583e72f67143a784ee058f37ec703e0b823ad0'
+            '68274851019f8ca0af50b63ef729474b3ecbb2eb8cce8569e8f74860748af8ab'
+            '3749782c560ff5c624ec195a597cd5a64c68badf53081c940708a8b481aa1b8d'
+            'e8ef64f2ad1f0afffd48dc700aad6caddcb50962a93a81669c6da5bc9c4cfffd'
+            '5dd6322b6abedd5fca7912cbaa0599b75ab953d1d0cbe44848786580f883147f'
+            '629f5b4b17ffc611f257b7e4d519c4656edb68647415b7235ece46b5604a7df5'
+            '095b71e35cb6246d9319fc5de9ba51fab6884f2d80d4ecf953511c7e34d8f5a4'
+            '688503ca68dea74c238e8074d992d19cf3254d4e7cc36a84edf2fa53ce75aad8'
+            '6724d147ab404430a455cc70bce0a1779e19564d5df9e0aa3ab8e703cfe73efd'
+            '46b677a3e8a691e6f01e1a70ee68456cdcb11d3e7969a5c04608b1bd4fa4042e'
+            'c447ceaf4d5e1e7c8d4ecfa8be95a227773b89b2f4d690aa606fe16a1fa68352'
+            '78cf91272eefa7f33b9b49be3d373be132e080871c3bbb4405d3290fd7a61d52'
+            '450db023d14a61fa444bdf3fd7f5edd0041066d8a9515944f38b8d7d5cf432a0'
+            '1afb47e0c2fdd3b00a435233da5e611e241f9d6d49ee613c236b62ed791099a8'
+            '7407c769165126b5010aae37d865dca69dd27a9421700dd8c7d631c2423cac18'
+            '9e4467ceccbd3e56966926a38de1833d5e390599d09e2c3e45c57db27353602b'
+            '354ec982e6fe94241c4925921c8c7abef9d9e1697b4533e8c70d1d4cb0cfa0b0'
+            '05d7f0057a0b324d625261ddf4b84e7bf1935b58e5fa4e43b13e995eda145b61'
+            'a8250895f80d50f43cf16e15531b47f0e79986880106323098c09db43cd1f143'
+            'fa7b230613d9c286ee549a57cc528701f8d0869846cc98bb580b60c435fa563a')
 
-)
-sha256sums=('SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-            'SKIP'
-	    'SKIP'
-	    'SKIP'
-	    'SKIP'
-
-)
 
 PKGEXT=".pkg.tar"
 


### PR DESCRIPTION
1. Added sha256sums for `*.deb`, please add the checksum for `flashback.patch`, it's not available yet on here.
2. Changed URL and cleaned up irrelevant notes from the previous template. Some similar cruft still remains like on lines `139-141`.

Boy O boy, this is a lot of packages...