### PR TITLE
Minor typos and package name fixups

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -162,10 +162,10 @@ package_regolith-i3 () {
     license=('MIT')
 #    install=amdgpu-core-meta.install
     arch=('x86_64')
-    depends=('i3-gaps' 'i3-status' 'xorg-server-common' 'xorg-server-devel' 'python-i3ipc' 'gnome-flashback' 
+    depends=('i3-gaps' 'i3status' 'xorg-server-common' 'xorg-server-devel' 'python-i3ipc' 'gnome-flashback' 
              'accountsservice' 'cups-pk-helper' 'libgtop' 'gnome-control-center' 'gnome-desktop' 
-	     'x11-xwininfo' 'libdbus' 'python-gobject' 'python-dbus' 'xorg-xprop' 'libev' 'pcre'
-	     'libconfig' 'xcb-uitl-image' 'xcb-util-renderutil'kkkkkkkkkkkkkkkkkkkkkkkkkssss
+	     'xorg-xwininfo' 'libdbus' 'python-gobject' 'python-dbus' 'xorg-xprop' 'libev' 'pcre'
+	     'libconfig' 'xcb-util-image' 'xcb-util-renderutil'
              'gnome-settings-daemon' 'playerctl')
     optdepends=('picom: For compositing/desktop effects (strongly recommended!'
 		'unclutter-xfixes-git: For unclutter')


### PR DESCRIPTION
Now it fails with:
```
makepkg -si
==> WARNING: The package group has already been built, installing existing packages...
==> Installing regolith-de package group with pacman -U...
loading packages...
resolving dependencies...
looking for conflicting packages...
:: regolith-i3 and i3-gaps are in conflict (i3-wm). Remove i3-gaps? [y/N] y
:: regolith-i3 and gnome-session are in conflict. Remove gnome-session? [y/N] y
error: failed to prepare transaction (could not satisfy dependencies)
:: unable to satisfy dependency 'i3-gaps' required by regolith-i3
==> WARNING: Failed to install built package(s).
```
Perhaps `i3-gaps` should be in the `provides` [section](https://github.com/gardotd426/regolith-de/blob/master/PKGBUILD#L172), but you have `i3-wm` in there instead?

@gardotd426 Are you on IRC?