### PR TITLE
Add basic instructions for testing in a VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,47 @@ Because of the way AUR packages work, combined with Ubuntu-specific idiosyncraci
 
 This package conflicts with `gnome-shell`, which means it also (unfortunately) will conflict with GDM. For some reason, `gnome-shell` is a hard dependency of the `gdm` package on Arch, but not Ubuntu. On Ubuntu, the Regolith Desktop Environment actually does conflict with GNOME, but not GDM or the `gnome-shell` package alone. But on Arch, whatever the conflict is, is present in the `gnome-shell` package.
 
+## Contributing
+
+PRs are welcome.
+
+If you would like to test this PKGBUILD, the first steps would be to try it out in a Virtual Machine.
+
+**Virtual Machine**
+
+1. Spin up a new VM with a fresh install of Arch Linux.
+
+2. Install git and download the source code for this repo.
+
+    ```
+    $ sudo pacman -Sy git
+    
+    $ mkdir -p ${HOME}/Downloads/build &&cd $_
+
+    $ git clone https://github.com/gardotd426/regolith-de.git && cd regolith-de
+    ```
+
+4. [Install the packages](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages)
+
+    ```
+    $ makepkg -si
+    ```
+
+5. Start Regolith Desktop Environment
+
+    One way to do this is to run the session from a manual xorg startup:
+
+    ```
+    $ sudo pacman -Sy xorg-xinit
+
+    $ echo 'exec i3-gnome-flashback-session' > ${HOME}/.xinitrc
+
+    $ startx
+    ```
+
 IF THIS MESSAGE IS STILL PRESENT, IT IS NOT READY FOR PRIME-TIME. EITHER DON'T TRY IT AT ALL, OR TRY AT YOUR OWN RISK. THERE IS NO WARRANTY. When I and anyone else working on this decide that it's ready, we will make it available in the AUR. 
+
+## Credits
 
 Credit to Kevin Gilmer @kgilmer for the creation of Regolith Linux as well as invaluable insight during the creation of this PKGBUILD. 
 Pull requests are welcome, the number of packages here is enormous (it is a full desktop environment, after all), and this is my first software/package management project of any kind. 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,14 @@ If you would like to test this PKGBUILD, the first steps would be to try it out 
     ```
     $ makepkg -si
     ```
+5. Install optional dependencies
 
-5. Start Regolith Desktop Environment
+    Until this PKGBUILD is live it isn't possible to include dependencies from the AUR. These will need to be installed manually while in testing.
+
+    [Install the following from the AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository#Installing_and_upgrading_packages) :
+    - [remontoire-git](https://aur.archlinux.org/packages/remontoire-git/) - For the help overlay
+
+6. Start Regolith Desktop Environment
 
     One way to do this is to run the session from a manual xorg startup:
 


### PR DESCRIPTION
I have been spinning up a few fresh installs for Arch to test this PKGBUILD following an extended conversation in issue #4 . The process varied from machine to machine but essentially came down to what is contained in this PR. Following these steps will be enough to load regolith-de in a VM and get the experience of using it.