### PR TITLE
fixed unsupported pacman commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you would like to test this PKGBUILD, the first steps would be to try it out 
 2. Install git and download the source code for this repo.
 
     ```
-    $ sudo pacman -Sy git
+    $ sudo pacman -Syu git
     
     $ mkdir -p ${HOME}/Downloads/build &&cd $_
 
@@ -53,7 +53,7 @@ If you would like to test this PKGBUILD, the first steps would be to try it out 
     The other way is of course to run the session from a manual xorg startup:
 
     ```
-    $ sudo pacman -Sy xorg-xinit
+    $ sudo pacman -Syu xorg-xinit
 
     $ echo 'exec regolith-session' > ${HOME}/.xinitrc
 


### PR DESCRIPTION
It is not recommended to _ever_ call just `pacman -Sy` because it can break your system, for more info see here: [Arch Wiki: Pacman: Partial upgrades are unsupported](https://wiki.archlinux.org/title/System_maintenance#Partial_upgrades_are_unsupported)

