### PR TITLE
Make terminal emulator binary overridable using Xresources

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -91,7 +91,8 @@ source=(http://ppa.launchpad.net/regolith-linux/release/ubuntu/pool/main/a/ayu-t
 	rofitheme.patch
 	midnight-rofi.patch
 	rofication.patch
-	regolith-look.patch)
+	regolith-look.patch
+	terminal-xres.patch)
 
 
 sha256sums=('6e8c3d2dbe8c192c40593c85c9c5f2f6fb29ea376e72770461b41b867a2dd996'
@@ -146,7 +147,8 @@ sha256sums=('6e8c3d2dbe8c192c40593c85c9c5f2f6fb29ea376e72770461b41b867a2dd996'
             '734b6fdfbfc78cd9c41b1c32e59ef15671a0ef650719fdedfc47f50c5ec633ad'
             '705c95cdfd5847cd6c7fafe123cbdc6c3f404407118967797210189157c52e5c'
             'ffc32c177754990e7f5f7126415bd8f2d210dd875ad5ae43b057299a7d395905'
-            '5f2b29ef8fb363a1121befa276d7e6251c8961b8819ac2d60a5ec2006f126c97')
+            '5f2b29ef8fb363a1121befa276d7e6251c8961b8819ac2d60a5ec2006f126c97'
+            'bb399da1b1391fdd99997489759ff447d44397bac293b63c06dbe1fe588ea4f4')
 
 
 PKGEXT='.pkg.tar.zst'
@@ -554,8 +556,8 @@ package_regolith-desktop-config () {
 #    rm "${pkgdir}"/usr/share/applications/reboot.desktop
 #    rm "${pkgdir}"/usr/share/applications/logout.desktop
 #    rm "${pkgdir}"/usr/share/applications/shutdown.desktop
-    sed -i 's/x-terminal-emulator/st/g' "${pkgdir}"/etc/regolith/i3/config
     cd "${pkgdir}"
+    patch "${pkgdir}"/etc/regolith/i3/config -i "${srcdir}"/terminal-xres.patch
     patch -Np1 -i "${srcdir}"/rofitheme.patch
     cd "${srcdir}"/regolith-rofication
     patch -Np1 -i "${srcdir}"/rofication.patch

--- a/terminal-xres.patch
+++ b/terminal-xres.patch
@@ -1,0 +1,14 @@
+diff --git a/config b/config
+index 0bf546d..62daad2 100644
+--- a/config
++++ b/config
+@@ -48,7 +48,8 @@ set_from_resource $alt  i3-wm.alt Mod1
+ 
+ ## Launch // Terminal // <> Enter ##
+ set_from_resource $i3-wm.binding.terminal i3-wm.binding.terminal Return
+-bindsym $mod+$i3-wm.binding.terminal exec /usr/bin/x-terminal-emulator
++set_from_resource $i3-wm.terminal.binary i3-wm.terminal.binary /usr/bin/st
++bindsym $mod+$i3-wm.binding.terminal exec $i3-wm.terminal.binary
+ 
+ ## Launch // Browser // <><Shift> Enter ##
+ set_from_resource $i3-wm.binding.browser i3-wm.binding.browser Shift+Return


### PR DESCRIPTION
This change makes the terminal emulator configurable using the Xresource `i3-wm.terminal.binary` instead of hardcoding it to `/usr/bin/st`. The default is still `/usr/bin/st`.